### PR TITLE
Использование request вместо get, чтобы проходили тесты hexlet

### DIFF
--- a/bin/page-loader
+++ b/bin/page-loader
@@ -28,7 +28,7 @@ $stackHandler = new StreamHandler('page-loader.log', Level::Debug);
 $stackHandler->getFormatter()->ignoreEmptyContextAndExtra();
 $log->pushHandler($stackHandler);
 
-$loader = new Loader(new Client(), new FilePathBuilder(), $log);
+$loader = new Loader(new Client(['verify' => false]), new FilePathBuilder(), $log);
 
 $command = new Command(null, $loader);
 $application->add($command);

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -56,7 +56,7 @@ class Loader
     {
         $parts = parse_url($url);
 
-        return rtrim($parts['scheme'].'://'.$parts['host'], '/').'/';
+        return rtrim(($parts['scheme'] ?? 'http').'://'.$parts['host'], '/').'/';
     }
 
     private function getFullUrl(string $url): string
@@ -158,7 +158,7 @@ class Loader
             $relativeImagePath = pathinfo($absoluteFolderPath, PATHINFO_FILENAME).'/'.$fileName;
             $this->logger?->debug("Download $elementUrl to $filePath");
             try {
-                $this->client->get($elementUrl, ['sink' => $filePath]);
+                $this->client->request('GET', $elementUrl, ['sink' => $filePath]);
             } catch (\Exception $exception) {
                 $this->logger?->error($exception->getMessage());
                 $this->warning[] = "It is not possible to download resource $elementUrl to $filePath";


### PR DESCRIPTION
Использование request вместо get, чтобы проходили тесты hexlet. Запрет проверки сертификата ssl